### PR TITLE
调整应用窗口大小，设置文本对话框居中显示

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import sys
 
-from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget, QVBoxLayout, QFileDialog
+from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget, QVBoxLayout, QFileDialog, QStyle
 from PyQt5.QtCore import Qt, QRect
 from PyQt5.QtGui import QStandardItem, QStandardItemModel
 
@@ -16,20 +16,25 @@ class MainWindow(FluentWindow):
         self.distance_Interface = DistanceInterface(self.stackedWidget)
         self.addSubInterface(self.distance_Interface, FluentIcon.SETTING, "距离可视化")
         
-        self.resize_and_center()
+        self.resize_and_center(0.7, 0.8)
 
-    def resize_and_center(self):
+    def resize_and_center(self, width_frac=0.8, height_frac=0.8):
+        """
+        设置窗口大小并居中
+
+        :param width_frac: 窗口宽度占屏幕可用区域的比例
+        :param height_frac: 窗口高度占屏幕可用区域的比例
+        """
         screen = QApplication.screenAt(self.pos())
         screen_geo: QRect = screen.availableGeometry()
 
-        w = screen_geo.width() // 2
-        h = screen_geo.height() // 2
+        # 设置窗口大小，最小宽度为300，最小高度为200
+        tw = max(300, int(screen_geo.width()  * width_frac))
+        th = max(200, int(screen_geo.height() * height_frac))
+        self.resize(tw, th)
 
-        self.resize(w, h)
-        self.move(
-            screen_geo.x() + (screen_geo.width() - w) // 2,
-            screen_geo.y() + (screen_geo.height() - h) // 2
-        )
+        rect = QStyle.alignedRect(Qt.LeftToRight, Qt.AlignCenter, self.size(), screen_geo)
+        self.move(rect.topLeft())
 
 
 if __name__ == "__main__":

--- a/pages/distance/controllers.py
+++ b/pages/distance/controllers.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import Qt
 from core.loader import FileLoader
 from core.distance import compute_distance_matrix, gaussian_discretization_fast
 from core.reduction import reduce_dimension
-from pages.distance.widgets import tableWidget, PlotWidget
+from pages.distance.widgets import tableWidget, PlotWidget, FileDialog
 
 
 class Controllers:
@@ -59,7 +59,7 @@ class Controllers:
             return False
 
         tab_title = {"data": "原始数据", "eudistance": "欧氏距离", "infodistance": "信息距离", "coordinates": "坐标"}  # 不同类型数据对应的 tab 栏标题
-        file_path, _ = QFileDialog.getOpenFileName(self.parent, "选择文件", "", "CSV Files (*.csv);;Text Files (*.txt)")
+        file_path, _ = FileDialog.getOpenFileName(self.parent, "选择文件", "", "CSV Files (*.csv);;Text Files (*.txt)")
         if file_path:
             # 读取文件数据
             data = self.loader.upload(file_path)
@@ -93,7 +93,7 @@ class Controllers:
             print(f"{type} 数据为空，无法下载。")
             return False
 
-        file_path, _ = QFileDialog.getSaveFileName(self.parent, "保存文件", "", "CSV Files (*.csv);;Text Files (*.txt)")
+        file_path, _ = FileDialog.getSaveFileName(self.parent, "保存文件", "", "CSV Files (*.csv);;Text Files (*.txt)")
         if file_path:
             result = self.loader.download(data, file_path)
             return result

--- a/pages/distance/widgets.py
+++ b/pages/distance/widgets.py
@@ -1,13 +1,48 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from PyQt5.QtGui import QShowEvent
+from PyQt5.QtWidgets import QWidget, QApplication, QVBoxLayout, QFileDialog
 from PyQt5.QtCore import Qt, QAbstractTableModel, QModelIndex
+
 from qfluentwidgets import TableView
+
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib import rcParams
-import numpy as np
 
+
+class FileDialog(QFileDialog):
+    def __init___(self, parent):
+        super().__init__(parent)
+        
+    def showEvent(self, a0: QShowEvent) -> None:
+        super().showEvent(a0)
+        self.setCenter(self.parent())
+
+    def setCenter(self, parent):
+        """
+        设置对话框的中心位置
+        :param center: 中心点坐标 (x, y)
+        """
+        if not self.isVisible():
+            self.adjustSize()
+                
+        # 以父窗口中心为目标点
+        parent_center = parent.frameGeometry().center()
+
+        # 把对话框的几何框移动到该中心
+        g = self.frameGeometry()
+        g.moveCenter(parent_center)
+
+        # 防止越界到屏幕外：按父窗口所在屏幕裁剪
+        screen = parent.screen() or QApplication.screenAt(parent_center) or QApplication.primaryScreen()
+        sgeo = screen.availableGeometry()
+        tl = g.topLeft()
+        x = max(sgeo.left(),  min(tl.x(), sgeo.right()  - g.width()  + 1))
+        y = max(sgeo.top(),   min(tl.y(), sgeo.bottom() - g.height() + 1))
+        self.move(x, y)
+    
 
 class DataFrameModel(QAbstractTableModel):
     """


### PR DESCRIPTION
### 主要修改
1. 设置主窗口大小：宽为屏幕70%，高为80%
2. 自定义文本对话框的显示事件，在原有显示过程的基础上添加居中显示